### PR TITLE
fix(Task, Section, Project): additional integer overflows for order

### DIFF
--- a/src/projects.rs
+++ b/src/projects.rs
@@ -14,7 +14,7 @@ pub struct Project {
     pub id: String,
     pub name: String,
     pub comment_count: u8,
-    pub order: u8,
+    pub order: i32,
     pub color: String,
     pub is_shared: bool,
     pub is_favorite: bool,

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct Section {
     pub id: String,
     pub project_id: String,
-    pub order: u16,
+    pub order: i32,
     pub name: String,
 }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -134,7 +134,7 @@ pub struct Task {
     pub is_completed: bool,
     pub labels: Vec<String>,
     pub parent_id: Option<String>,
-    pub order: u64,
+    pub order: i32,
     pub priority: u8,
     pub due: Option<Due>,
     pub url: String,


### PR DESCRIPTION
I hope it's ok to go straight for a pull request, with your last commit as a guide.

I am still getting invalid range errors, this time negative numbers. Using `jq`, I filtered out unique `order` from tasks, sections, and projects. Because `order` in one of my tasks is `2147483647`, which happens to be max signed int 32. I figured `i32` would be a safe choice.

### Tasks

```bash
curl --header "Authorization: Bearer <API_TOKEN>" https://api.todoist.com/rest/v2/tasks | jq -c 'sort_by(.order) | unique_by(.order) | [.[].order]'

[-9,-8,-7,-6,-5,-3,-2,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,24,25,2147483645,2147483646,2147483647]

```

### Sections

```bash
curl --header "Authorization: Bearer <API_TOKEN>" https://api.todoist.com/rest/v2/sections | jq -c 'sort_by(.order) | unique_by(.order) | [.[].order]'

[-1,0,1,2,3,4,5,6]
```

### Projects

Even though the numbers would fit, I figured for consistency, `order` for Project should be modified as well.

```bash
curl --header "Authorization: Bearer <API_TOKEN>" https://api.todoist.com/rest/v2/projects | jq -c 'sort_by(.order) | unique_by(.order) | [.[].order]'

[0,3,4,5,6,7,8,9,10]
```

Everything seems to be working. Now that I can run it, I like what I see so far!
