### PR TITLE
fix: reduce polling to lower CPU usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
         let mut app = app.lock().await;
         terminal.draw(|frame| tui::ui(frame, &mut app))?;
 
-        if event::poll(std::time::Duration::from_millis(16))? {
+        if event::poll(std::time::Duration::from_millis(150))? {
             if let event::Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
                     if app.show_task_editor {


### PR DESCRIPTION
Not sure if it's just my local workstation configuration but with the current polling rate I was seeing the following CPU usage at idle:

``` ps -p 62437 -o %cpu,%mem,cmd
%CPU %MEM CMD
 6.6  0.0 todoist
```
and with the polling tweak it drops to a more reasonable amount:

```ps -p 59907 -o %cpu,%mem,cmd
%CPU %MEM CMD
 0.5  0.0 todoist
```
I'd be interested to see if you also see this CPU change?
